### PR TITLE
Tom's branch

### DIFF
--- a/main/server/InfoHandler.java
+++ b/main/server/InfoHandler.java
@@ -6,6 +6,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 public class InfoHandler implements HttpHandler {
+
     private final TileMap tileMap;
     private final GameState gameState;
 
@@ -29,25 +30,15 @@ public class InfoHandler implements HttpHandler {
         Integer requestX = null;
 
         String query = exchange.getRequestURI().getQuery();
-        if (query != null && !query.isBlank()) {
-            try {
-                String[] parts = query.split("&");
-                for (String part : parts) {
-                    String[] kv = part.split("=", 2);
-                    if (kv.length != 2) {
-                        continue;
-                    }
-
-                    if ("y".equals(kv[0])) {
-                        requestY = Integer.parseInt(kv[1]);
-                    } else if ("x".equals(kv[0])) {
-                        requestX = Integer.parseInt(kv[1]);
-                    }
+        if (query != null) {
+            String[] parts = query.split("&");
+            for (String part : parts) {
+                String[] kv = part.split("=");
+                if ("y".equals(kv[0])) {
+                    requestY = Integer.parseInt(kv[1]);
+                } else if ("x".equals(kv[0])) {
+                    requestX = Integer.parseInt(kv[1]);
                 }
-            } catch (NumberFormatException e) {
-                exchange.sendResponseHeaders(204, -1);
-                exchange.close();
-                return;
             }
         }
 
@@ -57,8 +48,10 @@ public class InfoHandler implements HttpHandler {
             return;
         }
 
-        // Spec: only allow INFO for the player's current absolute location.
-        if (requestY != gameState.getPlayerY() || requestX != gameState.getPlayerX()) {
+        int playerY = gameState.getPlayerY();
+        int playerX = gameState.getPlayerX();
+
+        if (requestY != playerY || requestX != playerX) {
             exchange.sendResponseHeaders(204, -1);
             exchange.close();
             return;

--- a/main/server/MoveHandler.java
+++ b/main/server/MoveHandler.java
@@ -27,16 +27,15 @@ public class MoveHandler implements HttpHandler {
         int dy = 0;
         int dx = 0;
 
-        //get query from url
         String query = exchange.getRequestURI().getQuery();
 
-        if (query != null){
+        if (query != null) {
             String[] parts = query.split("&");
-            for (String part : parts){
+            for (String part : parts) {
                 String[] kv = part.split("=");
-                if (kv[0].equals("dy")){
+                if (kv[0].equals("dy")) {
                     dy = Integer.parseInt(kv[1]);
-                } else if (kv[0].equals("dx")){
+                } else if (kv[0].equals("dx")) {
                     dx = Integer.parseInt(kv[1]);
                 }
             }
@@ -56,12 +55,10 @@ public class MoveHandler implements HttpHandler {
             return;
         }
 
-        //work out new position 
         int newY = gameState.getPlayerY() + dy;
-        int newX = gameState.getPlayerX() + dx;
+        int newX = tileMap.wrapX(gameState.getPlayerX() + dx);
 
-        //check if blocked or out of bounds
-        if (tileMap.isBlocking(newY, newX)){
+        if (tileMap.isBlocking(newY, newX)) {
             exchange.sendResponseHeaders(204, -1);
             exchange.close();
             return;

--- a/main/server/TileMap.java
+++ b/main/server/TileMap.java
@@ -66,6 +66,16 @@ public class TileMap {
         return y >= 0 && y < height && x >= 0 && x < width;
     }
 
+    //Same horizontal wrap as the client 
+    public int wrapX(int x) {
+        int w = width;
+        if (w <= 0) {
+            return x;
+        }
+        int m = x % w;
+        return m < 0 ? m + w : m;
+    }
+
     public char getTileOrBlank(int y, int x) {
         if (!isInBounds(y, x)) {
             return ' ';

--- a/main/server/map.txt
+++ b/main/server/map.txt
@@ -3,9 +3,9 @@ SSSSSSggggWgt;tttggg
 SwwwwSgggWWgttttttgg
 SwwwwSggWWggtttttggg
 SSSDSSggWggtttgggggg
-ggg_gggWWWgtgggggggg
-.ggg_gggWgW.gggggggg
-____ggWWgWWggggg____
+gg,_gggWWWgtgggggggg
+.gg_gggWgW.ggggggggg
+____ggWWgWWgggg_____
 _gttgWWWggWgggg_gggg
 _ggtgWWgggWgggBDBggg
 _gggggggggWWggBfB.gg


### PR DESCRIPTION
fix(server): resolve client/server desync on horizontal map wrap
The client wraps x via fix_x (west from column 0 goes to width-1).
MoveHandler previously used raw x+delta, treating x < 0 as blocked and
returning 204 while the client updated position, desyncing state.
- TileMap: add wrapX(x) mirroring client horizontal modulus
- MoveHandler: compute newX with wrapX after dx; keep dy off-map blocking
  via existing isBlocking; leave minimal query parsing and CORS/OPTIONS as-is
- InfoHandler: drop experimental resync mode; strict spec behavior only
  (204 unless y,x match player); simplify query parsing to match MoveHandler
map.txt should match script.js map grid so tiles and blocking agree.